### PR TITLE
specified default value while resolving env variable

### DIFF
--- a/corn-backend/src/main/java/dev/corn/cornbackend/config/PlaceholderData.java
+++ b/corn-backend/src/main/java/dev/corn/cornbackend/config/PlaceholderData.java
@@ -52,7 +52,7 @@ public class PlaceholderData implements CommandLineRunner {
     private final ProjectMemberRepository projectMemberRepository;
     private final Random random = new Random(0);
 
-    @Value("${CREATE_PLACEHOLDER_DATA}")
+    @Value("${CREATE_PLACEHOLDER_DATA:false}")
     private String CREATE_PLACEHOLDER_DATA;
 
     @Override


### PR DESCRIPTION
prod, without CREATE_PLACEHOLDER_DATA envvar defined, was crashing. now it wont complain